### PR TITLE
Add Web Awesome Cookie-Based Docs

### DIFF
--- a/Web_Awesome_Cookie_Info.md
+++ b/Web_Awesome_Cookie_Info.md
@@ -1,0 +1,36 @@
+# WEB AWESOME COOKIE INFORMATION
+
+## Classification Level
+
+Publicly available
+
+## Review Information
+
+__Mandatory Review Period__
+
+Yearly
+
+__Date of Last Review__
+
+December 1, 2025
+
+## Introduction
+
+This cookie information document helps users identify what information we collect in cookie form and provides general information about how and why we use cookies.
+
+## Cookie Usage Statement
+
+Usage of cookies aligns with our [privacy policy](https://webawesome.com/privacy). Our general goal is to collect no more
+data about a user than is necessary to provide our service and prevent abuse.
+
+## Cookies
+
+| Cookie Developer | Cookie ID/Name | Associated Domain | Duration | Cookie Type | Description |
+| ---------------- | -------------- | ----------------- | -------- | ----------- | ----------- |
+| Fonticons, Inc. | connect.sid | webawesome.com | session or 30 days | Necessary | This is set by us and helps us validate the session for security purposes. When you check "Remember me" during login, this cookie persists for 30 days. Otherwise, it is cleared when you close your browser. |
+| Fonticons, Inc. | wa_cookie_settings | webawesome.com | 1 year | Necessary | This cookie holds the users cookie preferences to prevent unwanted cookies from being set. |
+| Stripe | __stripe_mid | .webawesome.com | 1 year | Necessary | Stripe sets this cookie as part of fraud detection and prevention when processing payments. |
+| Stripe | __stripe_sid | .webawesome.com | 1 hour | Necessary | Stripe sets this cookie as part of fraud detection and prevention when processing payments. |
+| Stripe | m | m.stripe.com | 1 year 1 month 4 days | Necessary | Stripe sets this cookie as part of fraud detection and prevention when processing payments. |
+| PostHog | ph_phc_* | .webawesome.com | 1 year | Analytics | This is the PostHog cookie for analytics and A/B testing. |
+| Vimeo | vuid | .vimeo.com | 1 year 1 month 4 days | Analytics | Vimeo installs this cookie to collect tracking information by setting a unique ID to embed videos on the website. |

--- a/Web_Awesome_Cookie_Policy.md
+++ b/Web_Awesome_Cookie_Policy.md
@@ -1,0 +1,60 @@
+# WEB AWESOME COOKIE POLICY
+
+## Classification Level
+
+Publicly available
+
+## Review Information
+
+**Mandatory Review Period**
+
+Yearly
+
+**Date of Last Review**
+
+December 1, 2025
+
+## Introduction
+
+A cookie policy helps users identify what information we collect in cookie form while also providing guidance on how and
+when it is acceptable for developers to add or modify cookies plus any specific steps required before rolling out cookie
+changes.
+
+### Goal Statement
+
+The cookie policy should specify how we address cookie related issues specifically. All technical aspects should be governed
+by other appropriate policies such as the privacy policy or change management policy (as it may apply practically). This
+policy should also clearly lay out what cookies we use and why.
+
+### Background Statement
+
+We, at Fonticons, Inc., know our culture and general attitude toward privacy concerns, etc. It is entirely reasonable for
+others planning to use our technology to desire to understand our goals and commitments around security and privacy. Cookie
+related questions have become common enough that it is appropriate to address specifics with an official policy.
+
+## Definitions
+
+### Terms
+
+- The word "we" shall mean Fonticons, Inc., all Fonticons, Inc. employees and any individuals contracting with Fonticons, Inc. to complete work.
+- Cookie shall mean a text file placed on you computer by our website. They have many purposes, mostly to allow for more advanced functionality that would not otherwise be possible via a static webpage. Some of these are absolutely necessary to provide a safe and functional experience.
+
+## Policy
+
+1. This policy applies to all employees.
+1. Cookies are collected for the purpose of:
+   1. Providing a consistent experience across the website by managing state between pages
+   1. Securing the site from bots and other unauthorized individuals
+   1. Determining and analyzing user traffic on the site
+   1. Allowing for secure payment schemes
+   1. Providing necessary functionality, such as icon search
+   1. Providing additional functionality, such as video
+   1. Providing features necessary to advertisers for free users
+1. Specific information about all cookies used on Web Awesome must be maintained and made generally available to anyone interested in the information.
+1. EU, UK, and Swiss Citizens (as determined by origin information from their connection) must be allowed to opt out of all cookies that are not strictly necessary.
+
+## Procedures
+
+1. An employee that detects any violation of this policy must report the issue to their supervisor, the head of development, the head of design, the head of security, or the CTO.
+1. Intentionally or maliciously violating this policy is a serious offense and grounds for termination of employment.
+1. Any questions, concerns, or clarifications should be directed to the head of security or privacy@awesome.me


### PR DESCRIPTION
This pull request adds comprehensive cookie-related documentation for Web Awesome, consisting of a formal cookie policy and detailed cookie information for public reference.

~~It also fixes some typos and grammatical issues in the Font Awesome docs that these are based on~~.

---

- @alexpoiry mind reviewing these additions and changes?